### PR TITLE
fixed: [ERROR:flutter/shell/common/shell.cc(1015)] sent a message from native to Flutter on a non-platform thread

### DIFF
--- a/windows/video_player_win_plugin.cpp
+++ b/windows/video_player_win_plugin.cpp
@@ -263,6 +263,7 @@ namespace video_player_win {
 // static
 void VideoPlayerWinPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows *registrar) {
+  g_registrar = registrar; //Jacky
   auto channel =
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
           registrar->messenger(), "video_player_win",
@@ -280,14 +281,6 @@ void VideoPlayerWinPlugin::RegisterWithRegistrar(
   texture_registar_ = registrar->texture_registrar(); //Jacky
   gMethodChannel = new flutter::MethodChannel<flutter::EncodableValue>(registrar->messenger(), "video_player_win",
           &flutter::StandardMethodCodec::GetInstance()); //Jacky
-
-  g_registrar = registrar; //Jacky
-
-  registrar->RegisterTopLevelWindowProcDelegate(
-    [&](HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-    {
-      return HandleWindowProc(hWnd, message, wParam, lParam);
-    });
 }
 
 std::optional<LRESULT> VideoPlayerWinPlugin::HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -304,9 +297,19 @@ std::optional<LRESULT> VideoPlayerWinPlugin::HandleWindowProc(HWND hWnd, UINT me
   return 0;
 }
 
-VideoPlayerWinPlugin::VideoPlayerWinPlugin() {}
+VideoPlayerWinPlugin::VideoPlayerWinPlugin() {
+  window_proc_id = g_registrar->RegisterTopLevelWindowProcDelegate(
+  [&](HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+  {
+    return HandleWindowProc(hWnd, message, wParam, lParam);
+  });
+}
 
 VideoPlayerWinPlugin::~VideoPlayerWinPlugin() {
+  if(window_proc_id != -1) {
+    g_registrar->UnregisterTopLevelWindowProcDelegate(window_proc_id);
+    window_proc_id = -1;
+  }
   texture_registar_ = NULL; //Jacky
   MFShutdown();
 }

--- a/windows/video_player_win_plugin.cpp
+++ b/windows/video_player_win_plugin.cpp
@@ -285,9 +285,10 @@ void VideoPlayerWinPlugin::RegisterWithRegistrar(
 
 std::optional<LRESULT> VideoPlayerWinPlugin::HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+  std::optional<LRESULT> result = std::nullopt;
   if (WM_FLUTTER_TASK != message)
   {
-    return 0;
+    return result;
   }
   flutter::EncodableMap arguments;
   arguments[flutter::EncodableValue("textureId")] = flutter::EncodableValue((INT64)wParam);

--- a/windows/video_player_win_plugin.h
+++ b/windows/video_player_win_plugin.h
@@ -20,6 +20,8 @@ class VideoPlayerWinPlugin : public flutter::Plugin {
   VideoPlayerWinPlugin(const VideoPlayerWinPlugin&) = delete;
   VideoPlayerWinPlugin& operator=(const VideoPlayerWinPlugin&) = delete;
 
+  static std::optional<LRESULT> HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
  private:
   // Called when a method is called on this plugin's channel from Dart.
   void HandleMethodCall(

--- a/windows/video_player_win_plugin.h
+++ b/windows/video_player_win_plugin.h
@@ -23,6 +23,9 @@ class VideoPlayerWinPlugin : public flutter::Plugin {
   static std::optional<LRESULT> HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
  private:
+   // The ID of the WindowProc delegate registration.
+  int window_proc_id = -1;
+
   // Called when a method is called on this plugin's channel from Dart.
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue> &method_call,


### PR DESCRIPTION
The 'video_player_win' channel sent a message from native to Flutter on a non-platform thread. Platform channel messages must be sent on the platform thread. Failure to do so may result in data loss or crashes, and must be fixed in the plugin or application code creating that channel。